### PR TITLE
V2.9.2

### DIFF
--- a/src/Apps/Flow/FlowScreen/shared/Vote/Vote.jsx
+++ b/src/Apps/Flow/FlowScreen/shared/Vote/Vote.jsx
@@ -25,6 +25,7 @@ const Vote = ({
   isVotingAllowed = true,
   isVotesHidden = true,
   isOneClickVotingEnabled = false,
+  shouldPrefetchComments = false,
 }) => {
   const [isCommentsPrefetched, setIsCommentsPrefetched] = useState(false);
   const rootStore = useContext(RootStoreContext);
@@ -38,11 +39,16 @@ const Vote = ({
   }, [screen?.name, hitCollection?.name, hit?.molecule?.name, hit?.id]);
 
   useEffect(() => {
-    if (!isCommentsPrefetched && !isFetchingComments) {
+    if (
+      shouldPrefetchComments &&
+      !isCommentsPrefetched &&
+      !isFetchingComments
+    ) {
       setIsCommentsPrefetched(true);
       fetchCommentsByTags(commentTags);
     }
   }, [
+    shouldPrefetchComments,
     isCommentsPrefetched,
     isFetchingComments,
     commentTags,

--- a/src/Apps/Flow/FlowScreen/shared/Vote/Vote.jsx
+++ b/src/Apps/Flow/FlowScreen/shared/Vote/Vote.jsx
@@ -165,7 +165,11 @@ const Vote = ({
           <div className="flex justify-content-center">
             <Button
               loading={isFetchingComments}
-              label={`Comments (${commentCount})`}
+              label={
+                shouldPrefetchComments
+                  ? `Comments (${commentCount})`
+                  : "Comments"
+              }
               icon="pi pi-comments"
               onClick={() => setIsDiscussionSideBarVisible(true)}
               className="p-button-sm p-button-plain p-button-text"

--- a/src/constants/appVersion.js
+++ b/src/constants/appVersion.js
@@ -1,5 +1,5 @@
 export const appVersion = {
-  release: "v2.9.1",
+  release: "v2.9.2",
   stream: "Enterprise",
   channel: "Valparaíso",
 };


### PR DESCRIPTION
This pull request introduces a new feature to control whether comments are prefetched in the `Vote` component. The main changes focus on making comment prefetching optional and updating the UI accordingly.

**Feature: Conditional Comment Prefetching**
* Added a new prop `shouldPrefetchComments` to the `Vote` component to allow toggling comment prefetch behavior.
* Updated the `useEffect` logic to only prefetch comments if `shouldPrefetchComments` is true, preventing unnecessary fetches.

**UI Updates**
* Modified the comments button label to show the comment count only when comments are prefetched; otherwise, it displays a generic "Comments" label.

**Version Update**
* Bumped the application version from `v2.9.1` to `v2.9.2` in `appVersion.js`.